### PR TITLE
refactor: adjust manipulations result output

### DIFF
--- a/src/metabolic_ninja/tasks.py
+++ b/src/metabolic_ninja/tasks.py
@@ -96,11 +96,20 @@ def predict(self, model_obj, product_name, max_predictions, aerobic,
     source = UNIVERSAL_SOURCES[databases]
     # Configure the model object for cameo.
     model = model_from_dict(model_obj["model_serialized"])
+    # FIXME: We should allow users to specify a medium that they previously
+    # uploaded.
     model.solver = "cplex"
+    # FIXME: This uses BiGG notation to change the lower bound of the
+    # exchange reaction. Should instead find this using a combination of
+    # metabolites in the `model.exchanges`, MetaNetX identifiers and/or
+    # metabolite formulae. Then set this on the `model.medium` to be sure
+    # about exchange direction.
     if not aerobic and "EX_o2_e" in model.reactions:
         model.reactions.EX_o2_e.lower_bound = 0
     model.biomass = model_obj["default_biomass_reaction"]
-    # We have to identify a carbon source from the medium.
+    # FIXME: We can try to be smart, as in theoretical yield app, but ideally
+    # the carbon source is user defined just like default_biomass_reaction.
+    # Maybe we need a new field for the medium database model?
     model.carbon_source = "EX_glc__D_e"
     # Define the workflow.
     workflow = (


### PR DESCRIPTION
The resulting 'tabular' output has a new column called `'knockouts'`. All reaction identifiers in that list should be displayed as delta + ID (possibly replaced with EC number if present). The `'manipulations'` column now contains a list of objects with keys `'id'`, `'value'` and `'direction'`.