### PR TITLE
Fetch user details before submitting job

### DIFF
--- a/deployment/deployment.yml
+++ b/deployment/deployment.yml
@@ -34,7 +34,9 @@ spec:
         - name: MODEL_STORAGE_API
           value: https://api-staging.dd-decaf.eu/mstorage
         - name: IAM_API
-          value: https://api-staging.dd-decaf.eu/iam
+          value: http://iam-staging/iam
+        - name: WAREHOUSE_API
+          value: http://warehouse-staging/warehouse
         - name: POSTGRES_HOST
           value: localhost
         - name: POSTGRES_PORT
@@ -107,10 +109,6 @@ spec:
             secretKeyRef:
               name: metabolic-ninja-staging
               key: SENDGRID_API_KEY
-        - name: IAM_API
-          value: http://iam-staging/iam
-        - name: WAREHOUSE_API
-          value: http://warehouse-staging/warehouse
         command: ["celery", "-A", "metabolic_ninja.tasks", "worker", "--loglevel=info"]
         resources:
           requests:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
     - POSTGRES_USERNAME=${POSTGRES_USERNAME:-postgres}
     - POSTGRES_PASS=${POSTGRES_PASS}
     - IAM_API=${IAM_API:-https://api-staging.dd-decaf.eu/iam}
+    - WAREHOUSE_API=${WAREHOUSE_API:-https://api-staging.dd-decaf.eu/warehouse}
     command: gunicorn -c gunicorn.py metabolic_ninja.wsgi:app
 
   worker:
@@ -53,8 +54,6 @@ services:
     - POSTGRES_USERNAME=${POSTGRES_USERNAME:-postgres}
     - POSTGRES_PASS=${POSTGRES_PASS}
     - SENDGRID_API_KEY=${SENDGRID_API_KEY}
-    - IAM_API=${IAM_API:-https://api-staging.dd-decaf.eu/iam}
-    - WAREHOUSE_API=${WAREHOUSE_API:-https://api-staging.dd-decaf.eu/warehouse}
     - C_FORCE_ROOT=1
     command: celery -A metabolic_ninja.tasks worker --loglevel=info
 

--- a/src/metabolic_ninja/tasks.py
+++ b/src/metabolic_ninja/tasks.py
@@ -18,7 +18,6 @@ from contextlib import contextmanager
 from itertools import chain as iter_chain
 
 import cameo.core.target as targets
-import requests
 import sentry_sdk
 from cameo.api import design
 from cameo.strain_design import DifferentialFVA, OptGene


### PR DESCRIPTION
This fixes the issue where the authorization token may have expired by the time the job is started.