### PR TITLE
chore: introduce a buffer in the timeout

### DIFF
--- a/src/metabolic_ninja/celery.py
+++ b/src/metabolic_ninja/celery.py
@@ -27,7 +27,7 @@ celery_app = Celery(
 celery_app.conf.update(
     task_track_started=True,
     # Time after which a running job will be interrupted.
-    task_time_limit=7200,  # 2 hours
+    task_time_limit=7260,  # 2 hours 1 minute
     # Time after which a successful result will be removed.
     result_expires=604800,  # 7 days
     # Reboot worker processes if consuming too much memory. This is a workaround


### PR DESCRIPTION
Currently, our longest running tasks are OptGene jobs and they have a time limit of 2 hours themselves. This introduces a small buffer before celery will interrupt the task.