### PR TITLE
Graceful redeploys

### DIFF
--- a/deployment/deployment.yml
+++ b/deployment/deployment.yml
@@ -14,6 +14,11 @@ spec:
         app: metabolic-ninja
         env: staging
     spec:
+      # Ensure running celery tasks are allowed to finish during warm shutdowns.
+      # The task expected to run for the longest is OptGene which has a timeout
+      # of 2 hours. The below value is then set to 2 hours plus 2 minutes to
+      # allow for some small overhead.
+      terminationGracePeriodSeconds: 7320
       containers:
       - name: web
         image: gcr.io/dd-decaf-cfbf6/metabolic-ninja:devel

--- a/requirements.in
+++ b/requirements.in
@@ -4,7 +4,10 @@ flask-apispec
 sentry-sdk[flask]
 gunicorn
 gevent
-celery[redis]
+# Use the latest pre-release of Celery to remedy the following issue with
+# graceful terminations, which occurs on 4.2.1:
+# https://github.com/celery/billiard/issues/260
+celery[redis] >= 4.3.0rc2
 redis
 flower
 # Flower 0.9.2 is not compatible with tornado 6, but does not constrain the


### PR DESCRIPTION
- Upgrading celery to the current pre-release is necessary to avoid this issue during warm shutdown: https://github.com/celery/billiard/issues/260
- Set k8s termination grace period to be longer than the longest expected task runtime. This should ensure that tasks are always run to completion before redeploying, and do not become stale (at least as long as the pod is terminated gracefully with SIGTERM).