### PR TITLE
Remove db migration on startup in order to start gunicorn directly

### DIFF
--- a/deployment/deployment.yml
+++ b/deployment/deployment.yml
@@ -70,8 +70,7 @@ spec:
               key: POSTGRES_PASS
         - name: WORKER_CONCURRENCY
           value: "4"
-        command: ["/bin/sh", "-c"]
-        args: ["flask db upgrade && gunicorn -c gunicorn.py metabolic_ninja.wsgi:app"]
+        command: ["gunicorn", "-c", "gunicorn.py", "metabolic_ninja.wsgi:app"]
         readinessProbe:
           httpGet:
             path: /pathways-caffeine/healthz

--- a/deployment/deployment.yml
+++ b/deployment/deployment.yml
@@ -19,6 +19,61 @@ spec:
       # of 2 hours. The below value is then set to 2 hours plus 2 minutes to
       # allow for some small overhead.
       terminationGracePeriodSeconds: 7320
+      initContainers:
+      - name: migrate
+        image: gcr.io/dd-decaf-cfbf6/metabolic-ninja:devel
+        imagePullPolicy: Always
+        env:
+        - name: ENVIRONMENT
+          value: production
+        - name: SCRIPT_NAME
+          value: /pathways-caffeine
+        - name: FLASK_APP
+          value: src/metabolic_ninja/wsgi.py
+        - name: ALLOWED_ORIGINS
+          value: https://caffeine.dd-decaf.eu,http://localhost:4200
+        - name: REDIS_HOST
+          value: localhost:6379
+        - name: MODEL_STORAGE_API
+          value: https://api-staging.dd-decaf.eu/mstorage
+        - name: IAM_API
+          value: http://iam-staging/iam
+        - name: WAREHOUSE_API
+          value: http://warehouse-staging/warehouse
+        - name: POSTGRES_HOST
+          value: localhost
+        - name: POSTGRES_PORT
+          value: "5432"
+        - name: POSTGRES_DB_NAME
+          value: metabolic_ninja
+        - name: SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: metabolic-ninja-staging
+              key: SECRET_KEY
+        - name: SENTRY_DSN
+          valueFrom:
+            secretKeyRef:
+              name: metabolic-ninja-staging
+              key: SENTRY_DSN
+        - name: POSTGRES_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: metabolic-ninja-staging
+              key: POSTGRES_USERNAME
+        - name: POSTGRES_PASS
+          valueFrom:
+            secretKeyRef:
+              name: metabolic-ninja-staging
+              key: POSTGRES_PASS
+        - name: WORKER_CONCURRENCY
+          value: "4"
+        command: ["flask", "db", "upgrade"]
+        resources:
+          requests:
+            cpu: "10m"
+          limits:
+            cpu: "2000m"
       containers:
       - name: web
         image: gcr.io/dd-decaf-cfbf6/metabolic-ninja:devel

--- a/deployment/deployment.yml
+++ b/deployment/deployment.yml
@@ -41,7 +41,7 @@ spec:
         - name: WAREHOUSE_API
           value: http://warehouse-staging/warehouse
         - name: POSTGRES_HOST
-          value: localhost
+          value: cloudsql-proxy
         - name: POSTGRES_PORT
           value: "5432"
         - name: POSTGRES_DB_NAME
@@ -98,7 +98,7 @@ spec:
         - name: WAREHOUSE_API
           value: http://warehouse-staging/warehouse
         - name: POSTGRES_HOST
-          value: localhost
+          value: cloudsql-proxy
         - name: POSTGRES_PORT
           value: "5432"
         - name: POSTGRES_DB_NAME
@@ -150,7 +150,7 @@ spec:
               name: metabolic-ninja-staging
               key: SENTRY_DSN
         - name: POSTGRES_HOST
-          value: localhost
+          value: cloudsql-proxy
         - name: POSTGRES_PORT
           value: "5432"
         - name: POSTGRES_DB_NAME
@@ -234,22 +234,7 @@ spec:
         volumeMounts:
           - mountPath: "/data"
             name: metabolic-ninja-staging
-      - name: cloudsql-proxy
-        image: gcr.io/cloudsql-docker/gce-proxy:1.11
-        command: ["/cloud_sql_proxy", "-instances=dd-decaf-cfbf6:europe-west1:dd-decaf=tcp:5432", "-credential_file=/secrets/cloudsql/credentials.json"]
-        resources:
-          requests:
-            cpu: "10m"
-          limits:
-            cpu: "2000m"
-        volumeMounts:
-          - name: cloudsql-instance-credentials
-            mountPath: /secrets/cloudsql
-            readOnly: true
       volumes:
         - name: metabolic-ninja-staging
           persistentVolumeClaim:
            claimName: metabolic-ninja-staging
-        - name: cloudsql-instance-credentials
-          secret:
-            secretName: cloudsql-instance-credentials


### PR DESCRIPTION
This removes the `flask db upgrade` command that's run on every new
deployment, thereby requiring us to perform db migrations manually now.

We could also consider doing this as part of the deployment script, but
it would likely require some downtime during redeploys.

The reasoning is that when started the old way through `/bin/sh`,
signals sent by kubernetes (like SIGTERM) aren't passed along to
gunicorn, and the server will not terminate as expected.

This was likely also the cause of db connection issues reported by Sentry
during shutdown - the proxy terminates, but the gunicorn server is
still running and queried by the health check service.

If this change is accepted, I'll propagate it to other services that use the
same logic.