### PR TITLE
chore: increase worker time limit

### DIFF
--- a/deployment/deployment.yml
+++ b/deployment/deployment.yml
@@ -16,9 +16,9 @@ spec:
     spec:
       # Ensure running celery tasks are allowed to finish during warm shutdowns.
       # The task expected to run for the longest is OptGene which has a timeout
-      # of 2 hours. The below value is then set to 2 hours plus 2 minutes to
+      # of 2 hours. The below value is then set to 3 hours plus 2 minutes to
       # allow for some small overhead.
-      terminationGracePeriodSeconds: 7320
+      terminationGracePeriodSeconds: 10920
       initContainers:
       - name: migrate
         image: gcr.io/dd-decaf-cfbf6/metabolic-ninja:devel

--- a/src/metabolic_ninja/celery.py
+++ b/src/metabolic_ninja/celery.py
@@ -27,7 +27,7 @@ celery_app = Celery(
 celery_app.conf.update(
     task_track_started=True,
     # Time after which a running job will be interrupted.
-    task_time_limit=7260,  # 2 hours 1 minute
+    task_time_limit=10800,  # 3 hours
     # Time after which a successful result will be removed.
     result_expires=604800,  # 7 days
     # Reboot worker processes if consuming too much memory. This is a workaround


### PR DESCRIPTION
Need to set a larger time buffer since `optgene.run`'s `max_time` covers only the heuristic optimization but the call itself takes longer.