### PR TITLE
chore: elevate log level

### DIFF
--- a/src/metabolic_ninja/worker/designer.py
+++ b/src/metabolic_ninja/worker/designer.py
@@ -65,7 +65,7 @@ def differential_fva_optimization(pathway, model):
         try:
             designs = predictor.run(progress=False)
         except ZeroDivisionError as error:
-            logger.warning(
+            logger.error(
                 "Encountered the following error in DiffFVA.", exc_info=error
             )
             designs = None


### PR DESCRIPTION
This will mean that the error is picked up by Sentry thus notifying us
and giving us a chance to investigate and fix this.